### PR TITLE
PM2 Integration for Production Process Management   

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "serve": "tsup src/index.ts --format=esm --dts --out-dir=dist && node dist/index.js"
+    "build": "tsup src/index.ts --format=esm --dts --out-dir=dist",
+    "serve": "npm run build && node dist/index.js",
+    "node:start": "npm run build && pm2 start pm2.config.cjs",
+    "node:stop": "pm2 stop diiisco-node",
+    "node:restart": "npm run build && pm2 restart diiisco-node",
+    "node:status": "pm2 status diiisco-node",
+    "node:logs": "pm2 logs diiisco-node --lines 100",
+    "node:monit": "pm2 monit"
   },
   "author": "",
   "license": "ISC",
@@ -26,7 +33,7 @@
     "@libp2p/mplex": "^12.0.6",
     "@libp2p/peer-id-factory": "^4.2.4",
     "@libp2p/tcp": "^11.0.5",
-    "@libp2p/utils": "^7.0.1",
+    "@libp2p/utils": "^7.0.10",
     "@libp2p/yamux": "^8.0.1",
     "@multiformats/multiaddr": "^13.0.1",
     "@txnlab/nfd-sdk": "0.10.1",
@@ -47,7 +54,8 @@
     "msgpack-lite": "^0.1.26",
     "msgpackr": "^1.11.5",
     "openai": "^6.5.0",
-    "peer-id": "^0.16.0"
+    "peer-id": "^0.16.0",
+    "pm2": "^6.0.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/pm2.config.cjs
+++ b/pm2.config.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  apps: [{
+    name: 'diiisco-node',
+    script: 'dist/index.js',
+
+    // Process management
+    instances: 1,              // Single instance (P2P node should not cluster)
+    autorestart: true,         // Auto-restart on crash
+    max_restarts: 10,          // Limit restart attempts
+    restart_delay: 5000,       // Wait 5s between restarts
+
+    // Graceful shutdown
+    kill_timeout: 10000,       // 10s for graceful shutdown
+    wait_ready: true,          // Wait for process.send('ready')
+    listen_timeout: 30000,     // 30s startup timeout
+
+    // Logging
+    log_file: './logs/diiisco-combined.log',
+    out_file: './logs/diiisco-out.log',
+    error_file: './logs/diiisco-error.log',
+    log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+    merge_logs: true,
+
+    // Environment
+    env: {
+      NODE_ENV: 'production'
+    }
+  }]
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -132,9 +132,9 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
     });
   });
 
-  app.listen(port, '0.0.0.0', () => {
+  const server = app.listen(port, '0.0.0.0', () => {
     logger.info(`🚀 API server listening at ${environment.node?.url || `http://0.0.0.0:${port || 8080}`}`);
   });
 
-  return app;
+  return { app, server };
 };


### PR DESCRIPTION
This PR adds PM2 process management support for running the Diiisco node in production environments. The integration includes a pre-configured pm2.config.cjs with sensible defaults (auto-restart on crash, structured logging to ./logs/, and a 10-second graceful shutdown window), along with graceful shutdown handling that properly tears down the application in order—closing the API server, stopping health checks, unsubscribing from pubsub topics, and cleanly stopping the libp2p node. The application now signals PM2 when it's ready via process.send('ready'), and new npm scripts (pm2:start, pm2:stop, pm2:restart, pm2:logs, pm2:status) provide convenient commands for managing the process lifecycle.   