### PR TITLE
Bug/token pricing

### DIFF
--- a/Install-DiiiscoNode.ps1
+++ b/Install-DiiiscoNode.ps1
@@ -1166,8 +1166,8 @@ function Create-EnvironmentConfig {
     $llmApiKey = Read-Host "`nLLM API Key (leave blank if not needed - Ollama doesn't require one)"
     if ([string]::IsNullOrWhiteSpace($llmApiKey)) { $llmApiKey = "" }
     
-    $chargePer1K = Read-Host "Charge per 1K tokens (default) [0.000001]"
-    if ([string]::IsNullOrWhiteSpace($chargePer1K)) { $chargePer1K = "0.000001" }
+    $chargePer1M = Read-Host "Charge per 1M tokens (default) [0.001]"
+    if ([string]::IsNullOrWhiteSpace($chargePer1M)) { $chargePer1M = "0.001" }
     
     # --- Algorand Configuration ---
     Write-Host "`n--- Algorand Wallet Settings ---" -ForegroundColor Yellow
@@ -1254,8 +1254,8 @@ const environment: Environment = {
     baseURL: "$llmBaseURL",
     port: $llmPort,
     apiKey: "$llmApiKey",
-    chargePer1KTokens: {
-      default: $chargePer1K,
+    chargePer1MTokens: {
+      default: $chargePer1M,
     }
   },
   algorand: {

--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,9 @@ const environment: Environment = {
     baseURL: "http://localhost",
     port: 11434,                          // Default Ollama port
     apiKey: "",                           // Usually not needed for local LLMs
-    chargePer1KTokens: {
-      default: 0.000001,                  // Price per 1K tokens in ALGO
-      "gpt-oss:20b": 0.000002,            // Custom pricing per model
+    chargePer1MTokens: {
+      default: 0.001,                     // Price per 1M tokens in USDC
+      "gpt-oss:20b": 0.002,               // Custom pricing per model
     }
   },
   algorand: {

--- a/src/environment/environment.types.ts
+++ b/src/environment/environment.types.ts
@@ -21,7 +21,11 @@ export interface ModelsConfig {
   baseURL: string;
   port: number;
   apiKey: string;
-  chargePer1KTokens: {
+  chargePer1MTokens?: {
+    default: number;
+    [key: string]: number;
+  };
+  chargePer1KTokens?: {
     default: number;
     [key: string]: number;
   };

--- a/src/environment/example.environment.ts
+++ b/src/environment/example.environment.ts
@@ -12,9 +12,9 @@ const environment: Environment = {
     baseURL: "http://localhost",
     port: 11434,
     apiKey: "YOUR_LOCAL_LLM_API_KEY_HERE_OFTEN_NOT_NEEDED",
-    chargePer1KTokens: {
-      default: 0.000001,
-      "gpt-oss:20b": 0.000002,
+    chargePer1MTokens: {
+      default: 0.01703,
+      "gpt-oss:20b": 0.02,
     }
   },
   algorand: {

--- a/src/messaging/messageProcessor.ts
+++ b/src/messaging/messageProcessor.ts
@@ -174,7 +174,7 @@ export class MessageProcessor {
           model: msg.payload.model,
           inputCount: msg.payload.inputs.length,
           tokenCount: rawQuote.tokens,
-          pricePer1K: rawQuote.rate,
+          pricePer1M: rawQuote.rate,
           totalPrice: rawQuote.price,
           addr: this.algo.account.addr.toString(),
         },

--- a/src/pubsub/handler.ts
+++ b/src/pubsub/handler.ts
@@ -96,7 +96,7 @@ export const handlePubSubMessage = async (
             model: quoteRequestMsg.payload.model,
             inputCount: quoteRequestMsg.payload.inputs.length,
             tokenCount: rawQuote.tokens,
-            pricePer1K: rawQuote.rate,
+            pricePer1M: rawQuote.rate,
             totalPrice: rawQuote.price,
             addr: algo.account.addr.toString(),
           },

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -19,7 +19,7 @@ export interface QuoteResponsePayload {
   model: string;
   inputCount: number;
   tokenCount: number;
-  pricePer1K: number;
+  pricePer1M: number;
   totalPrice: number;
   addr: string;
 }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -42,8 +42,18 @@ export class OpenAIInferenceModel {
 
   async countEmbeddings(model: string, inputs: any[]) {
     return inputs.reduce((acc, input) => {
-      const text = typeof input === 'string' ? input : (input.content || '');
-      const tokens = tokenizer.encode(String(text));
+      let text: string;
+      if (typeof input === 'string') {
+        text = input;
+      } else if (Array.isArray(input.content)) {
+        text = input.content
+          .filter((part: any) => part.type === 'text')
+          .map((part: any) => part.text)
+          .join('');
+      } else {
+        text = input.content || '';
+      }
+      const tokens = tokenizer.encode(text);
       return acc + tokens.length;
     }, 0);
   }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -40,9 +40,10 @@ export class OpenAIInferenceModel {
     return resp.data;
   }
 
-  async countEmbeddings(model: string, inputs: string[]) {
+  async countEmbeddings(model: string, inputs: any[]) {
     return inputs.reduce((acc, input) => {
-      const tokens = tokenizer.encode(input);
+      const text = typeof input === 'string' ? input : (input.content || '');
+      const tokens = tokenizer.encode(String(text));
       return acc + tokens.length;
     }, 0);
   }

--- a/src/utils/quoteCreationMethods.ts
+++ b/src/utils/quoteCreationMethods.ts
@@ -3,13 +3,27 @@ import { QuoteRequest } from "../types/messages";
 import { RawQuote } from "../types/quotes";
 import { OpenAIInferenceModel } from "./models";
 
+// Resolve the per-1M token rate for a given model.
+// Prefers chargePer1MTokens; falls back to chargePer1KTokens (converted to per-1M).
+function getRatePer1M(model: string): number {
+  const per1M = environment.models.chargePer1MTokens;
+  if (per1M) {
+    return per1M[model] || per1M.default || 0.001;
+  }
+  const per1K = environment.models.chargePer1KTokens;
+  if (per1K) {
+    return (per1K[model] || per1K.default || 0.000001) * 1000;
+  }
+  return 0.001;
+}
+
 // Create Quote from Input Tokens ONLY
 export async function createQuoteFromInputTokens(quoteRequestMsg: QuoteRequest, model: OpenAIInferenceModel): Promise<RawQuote | null> {
   console.log("Creating quote from input tokens...");
   const tokens: number = await model.countEmbeddings(quoteRequestMsg.payload.model, quoteRequestMsg.payload.inputs);
-  const rate = environment.models.chargePer1KTokens[quoteRequestMsg.payload.model] || environment.models.chargePer1KTokens.default || 0.000001;
+  const rate = getRatePer1M(quoteRequestMsg.payload.model);
 
-  const price = parseFloat(((tokens / 1000) * rate).toFixed(6));
+  const price = parseFloat(((tokens / 1_000_000) * rate).toFixed(6));
 
   return {
     price,
@@ -21,9 +35,9 @@ export async function createQuoteFromInputTokens(quoteRequestMsg: QuoteRequest, 
 //Create Quote from Multiple of Input Tokens
 export async function createQuoteFromMultipleOfInputTokens(quoteRequestMsg: QuoteRequest, model: OpenAIInferenceModel): Promise<RawQuote | null> {
   const tokens: number = await model.countEmbeddings(quoteRequestMsg.payload.model, quoteRequestMsg.payload.inputs);
-  const rate = environment.models.chargePer1KTokens[quoteRequestMsg.payload.model] || environment.models.chargePer1KTokens.default || 0.000001;
+  const rate = getRatePer1M(quoteRequestMsg.payload.model);
 
-  const price = parseFloat(((tokens / 1000) * rate).toFixed(6)) * 2; // Price the quote at two times the size of the input tokens
+  const price = parseFloat(((tokens / 1_000_000) * rate).toFixed(6)) * 2; // Price the quote at two times the size of the input tokens
 
   return {
     price,
@@ -35,9 +49,9 @@ export async function createQuoteFromMultipleOfInputTokens(quoteRequestMsg: Quot
 // Create Quote from Output Tokens ONLY
 export async function createQuoteFromOutputTokens(quoteRequestMsg: QuoteRequest, model: OpenAIInferenceModel): Promise<RawQuote | null> {
   const tokens: number = (await model.getResponse(quoteRequestMsg.payload.model, quoteRequestMsg.payload.inputs)).usage?.total_tokens || 1;
-  const rate = environment.models.chargePer1KTokens[quoteRequestMsg.payload.model] || environment.models.chargePer1KTokens.default || 0.000001;
+  const rate = getRatePer1M(quoteRequestMsg.payload.model);
 
-  const price = parseFloat(((tokens / 1000) * rate).toFixed(6));
+  const price = parseFloat(((tokens / 1_000_000) * rate).toFixed(6));
 
   return {
     price,
@@ -49,9 +63,9 @@ export async function createQuoteFromOutputTokens(quoteRequestMsg: QuoteRequest,
 // Create Quote from Fixed price of $0.01
 export async function createQuoteFromFixedPrice(quoteRequestMsg: QuoteRequest, model: OpenAIInferenceModel): Promise<RawQuote | null> {
   const tokens: number = await model.countEmbeddings(quoteRequestMsg.payload.model, quoteRequestMsg.payload.inputs);
-  const rate = environment.models.chargePer1KTokens[quoteRequestMsg.payload.model] || environment.models.chargePer1KTokens.default || 0.000001;
+  const rate = getRatePer1M(quoteRequestMsg.payload.model);
 
-  const price = 0.01; // Fixed price of $0.01for any request
+  const price = 0.01; // Fixed price of $0.01 for any request
 
   return {
     price,


### PR DESCRIPTION
Fixes a bug where the quote price was always the same regardless of input query length.

The root cause was that countEmbeddings was passing ChatCompletionMessageParam objects directly to the tokenizer, which coerced each one to the string "[object Object]", producing a constant token count every time. The fix extracts the actual message content before tokenizing, handling both plain string and multi-part content formats ({type: "text", text: "..."}).

Additionally, the pricing model has been migrated from per-1K tokens to per-1M tokens to align with industry standards, with backward compatibility for existing chargePer1KTokens configurations which are auto-converted.