### PR TITLE
Checks for PM2 in index.ts at runtime.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,8 @@ export { Application };
 export { configureEnvironment } from './environment/environment';
 export type { Environment } from './environment/environment.types';
 
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+const isMainModule = import.meta.url === `file://${process.argv[1]}`
+  || typeof process.env.pm_id !== 'undefined';
 
 if (isMainModule) {
   const app = new Application();


### PR DESCRIPTION
When the server is cerated, it checks to see if it is running a s amain script (as opposed to being called by a module). This works for the mac and Windows Apps but not for PM2. This fix alters that.