### PR TITLE
Add custom wait time for /network requests.

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -48,7 +48,7 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
   app.get('/network', async (req, res) => {
     try {
       const nodes: NetworkNode[] = [];
-      const waitTime = environment.quoteEngine?.waitTime || 5000;
+      const waitTime = environment.api?.networkWaitTime || 5000;
 
       const onNodeReceived = (node: NetworkNode) => {
         nodes.push(node);

--- a/src/environment/environment.types.ts
+++ b/src/environment/environment.types.ts
@@ -36,6 +36,7 @@ export interface ApiConfig {
   bearerAuthentication: boolean;
   keys: string[];
   port: number;
+  networkWaitTime: number;
 }
 
 


### PR DESCRIPTION
Adds an environment variable that allows you to wait a set amount of time for a network signal to come back to you.