### PR TITLE
waitForMesh Replacement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,30 +1,47 @@
 <img src="https://github.com/Diiisco-Inc/diiisco-node/blob/main/assets/diiisco-logo.png?raw=true" width="1000" />
 
-Diiisco is a globally distributed peer-to-peer network for running large language models. Send a prompt to any node on the network and receive a response from the model of your choice. Contributors earn Algorand for providing compute power.
 
-## 👋 Join the Network
+<p align="center">
+  <a href="https://diiisco.com"><img src="https://img.shields.io/badge/Website-diiisco.com-black?style=flat-square&logoColor=white" alt="Website" /></a>
+  &nbsp;
+  <a href="https://diiisco.com/docs/welcome"><img src="https://img.shields.io/badge/Docs-diiisco.com/docs-black?style=flat-square&logoColor=white" alt="Docs" /></a>
+  &nbsp;
+  <a href="https://x.com/diiiscohq"><img src="https://img.shields.io/badge/X-@diiiscohq-black?style=flat-square&logo=x&logoColor=white" alt="X" /></a>
+  &nbsp;
+  <a href="https://discord.gg/WcuuVcrHFa"><img src="https://img.shields.io/badge/Discord-Join_Us-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord" /></a>
+</p>
 
-Joining the network is easy. You'll need:
+DIIISCO is a peer-to-peer network for running large language models. Any node on the network can send an inference request; any node running a compatible model can fulfil it and earn, settled instantly on Algorand.
+
+DIIISCO is open-source and free forever. Any application that calls an OpenAI Copatable API can be used with DIIISCO.
+
+---
+
+## 🪩 How DIIISCO works
+
+When a request arrives at a DIIISCO node, it is broadcast to the network as a quote request. Nodes that can serve the model respond with a price. The best quote is selected, an on-chain escrow contract is created, inference runs, and payment is released automatically on delivery. Nodes that don't need payment such as private clusters, skip the contract entirely and serve inference directly overf the network.
+
+### Public network (payments enabled)
+
+Nodes connect to the global DIIISCO network. Requesters pay providers in USDC; providers earn DSCO tokens as an additional reward. Requires an Algorand wallet on each node.
+
+### Private network (payments disabled)
+
+A cluster of nodes you control, isolated from the public network by a unique topic name. No Algorand wallets required — nodes generate an ephemeral signing key at startup. Useful for home labs, office clusters, or any situation where you want distributed inference without blockchain overhead.
+
+---
+
+## 📋 Requirements
 
 - **Node.js 22** or higher
-- **A local LLM runtime** such as [Ollama](https://ollama.com/) or [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy)
-- **An Algorand wallet** for receiving payments (we recommend [Pera Wallet](https://perawallet.app/))
+- **An LLM runtime** — [Ollama](https://ollama.com/) or any OpenAI-compatible backend (e.g. [Shimmy](https://github.com/Michael-A-Kuykendall/shimmy))
+- **An Algorand wallet** — required for the public network only (we recommend [Pera Wallet](https://perawallet.app/))
 
-### 🦙 Run Your Own Large Language Model
+> ⚠️ **Never share your mnemonic.** Never enter it on a device you don't control.
 
-Download and install [Ollama](https://ollama.com/) or follow the [Shimmy installation guide](https://github.com/Michael-A-Kuykendall/shimmy). Once installed, download a model appropriate for your hardware:
+---
 
-- **Laptops**: Small models (7B parameters or less)
-- **Desktop PCs**: Medium models (13B-30B parameters)
-- **Gaming PCs / GPUs**: Large models (30B+ parameters)
-
-### 💰 Get Setup with Algorand
-
-Download [Pera Wallet](https://perawallet.app/) on iOS or Android. You'll need your wallet address and 25-word mnemonic passphrase.
-
-> **Warning**: Never share or enter your mnemonic on a device you don't control. Keep it secret, keep it safe.
-
-### 📦 Download and Install Diiisco Node
+## 📦 Installation
 
 ```bash
 git clone https://github.com/Diiisco-Inc/diiisco-node.git
@@ -32,178 +49,337 @@ cd diiisco-node
 npm install
 ```
 
-### 🌍 Set Your Environment
+---
 
-Copy the example environment file and edit it with your settings:
+## ⚙️ Configuration
+
+Copy the example configuration and edit it:
 
 ```bash
 cp src/environment/example.environment.ts src/environment/environment.ts
 ```
 
-Edit `src/environment/environment.ts` with your configuration:
+### 🌐 Public network configuration
 
 ```typescript
+import { Environment } from "./environment.types";
+import { selectHighestStakeQuote } from "../utils/quoteSelectionMethods";
+import { createQuoteFromInputTokens } from "../utils/quoteCreationMethods";
+
 const environment: Environment = {
   peerIdStorage: {
-    path: "~/Desktop/"                      // Where to store your peer identity
+    path: "~/Desktop/"               // Where to store your persistent peer identity
   },
   models: {
     enabled: true,
     baseURL: "http://localhost",
-    port: 11434,                            // Default Ollama port
-    apiKey: "",                             // Usually not needed for local LLMs
+    port: 11434,                     // Default Ollama port
+    apiKey: "",                      // Usually not needed for local LLMs
     chargePer1MTokens: {
-      default: 0.001,                       // Price per 1M tokens in USDC
-      "gpt-oss:20b": 0.002,                 // Per-model override
+      default: 0.01703,              // Price per 1M tokens in USDC
+      "llama3:8b": 0.01,             // Per-model price override
     }
   },
   algorand: {
-    addr: "YOUR_ALGORAND_ADDRESS_HERE",
-    mnemonic: "YOUR_ALGORAND_MNEMONIC_HERE",
+    addr: "YOUR_ALGORAND_ADDRESS",
+    mnemonic: "YOUR_25_WORD_MNEMONIC",
     network: "mainnet",
     client: {
       address: "https://mainnet-api.algonode.cloud/",
       port: 443,
       token: ""
     },
-    nfd: "your-name.diiisco.algo",          // Optional: NFD domain for verified identity
+    nfd: "your-name.diiisco.algo",   // Optional — see Verified Identity below
   },
   api: {
     enabled: true,
     bearerAuthentication: true,
-    keys: [
-      "sk-your-api-key-1",
-      "sk-your-api-key-2"
-    ],
-    port: 8080
+    keys: ["sk-your-key"],
+    port: 8080,
+    networkWaitTime: 10000,          // How long to collect /network responses (ms)
   },
   quoteEngine: {
-    waitTime: 1000,
+    waitTime: 1000,                  // How long to collect quotes before selecting (ms)
     quoteSelectionFunction: selectHighestStakeQuote,
     quoteCreationFunction: [createQuoteFromInputTokens],
-    preferSelf: false,                      // Set true to serve requests locally instead of earning DSCO
+    preferSelf: true,                // Serve locally when model is available, skipping the network
   },
   libp2pBootstrapServers: [
     "lon.diiisco.algo",
     "nyc.diiisco.algo",
   ],
   node: {
-    url: "http://localhost",
-    port: 4242,                             // Port for node-to-node communication
-    displayName: "My Diiisco Node",
+    url: "http://mynode.example.com",
+    port: 4242,
+    displayName: "My DIIISCO Node",
   },
-}
+};
+
+export default environment;
 ```
 
-#### `algorand.nfd`: NFD Domain (optional)
+### 🔒 Private network configuration
 
-[NFD (Non-Fungible Domain)](https://app.nf.domains/name/diiisco.algo?view=segments) is an Algorand naming service. Setting this field links your node to a human-readable `.diiisco.algo` domain, providing a verified on-chain identity that other nodes on the network can trust. Your NFD record must have a custom property `diiiscohost` set to your node's full libp2p multiaddr (e.g. `/dns4/mynode.example.com/tcp/4242/p2p/<your-peer-id>`)
-
-If the NFD check fails at startup, your node will still operate normally but peers will simply see an unverified identity.
-
-#### `quoteEngine.preferSelf`: Local-First Inference (default: `true`)
-
-When `preferSelf` is `true`, a node will serve a request directly from its own model if the requested model is available locally, without broadcasting a quote request to the network. This eliminates network round-trip latency.
-
-### 🚀 You're Ready to Go
-
-For development or testing, build and run with:
-
-```bash
-npm run serve
-```
-
-This command builds the project and starts the node in a single step.
-
-### 🖥️ Production Deployment
-
-For running your node as a background service, use the PM2 commands:
-
-```bash
-# Start the node
-npm run node:start
-
-# Check status
-npm run node:status
-
-# View logs
-npm run node:logs
-
-# Monitor in real-time
-npm run node:monit
-
-# Restart the node
-npm run node:restart
-
-# Stop the node
-npm run node:stop
-```
-
-## ❤️ Love Diiisco, Use Diiisco
-
-Every Diiisco node exposes REST API endpoints compatible with the OpenAI API standard. This means you can use Diiisco as a drop-in replacement in any codebase that uses the OpenAI API or SDK.
-
-Point your OpenAI client to your node's API endpoint (default: `http://localhost:8080`) and use one of your configured API keys for authentication.
-
-Diiisco is open-source and free forever.
-
-## 🏠 Running a Private Network
-
-You can run Diiisco on a private network, for example, across machines you own in a home lab, office, or cloud environment, without any Algorand payments. In this mode, all nodes serve inference requests freely to any peer on the network.
-
-### Setting up a private network
-
-On each node, configure the `local` block and remove the `algorand` block entirely:
+Remove the `algorand` block and add a `local` block. Each node still needs its own `peerIdStorage` path.
 
 ```typescript
 const environment: Environment = {
-  peerIdStorage: {
-    path: "~/Desktop/"
-  },
+  peerIdStorage: { path: "~/Desktop/" },
   models: {
     enabled: true,
     baseURL: "http://localhost",
     port: 11434,
     apiKey: "",
-    chargePer1MTokens: {
-      default: 0.001,
-    }
+    chargePer1MTokens: { default: 0.01703 }
   },
   api: {
     enabled: true,
     bearerAuthentication: true,
-    keys: ["sk-your-api-key"],
-    port: 8080
+    keys: ["sk-your-key"],
+    port: 8080,
+    networkWaitTime: 10000,
   },
   quoteEngine: {
     waitTime: 1000,
     quoteCreationFunction: [createQuoteFromInputTokens],
   },
   libp2pBootstrapServers: [
-    "/ip4/192.168.1.10/tcp/4242/p2p/<peer-id>",  // your own bootstrap node
+    "/ip4/192.168.1.10/tcp/4242/p2p/<peer-id-of-your-bootstrap-node>",
   ],
   node: {
-    url: "http://localhost",
     port: 4242,
     displayName: "My Private Node",
   },
   local: {
     enabled: true,
-    privateTopic: "my-org/models/1.0.0"           // unique name for your network
+    privateTopic: "acme-corp/models/1.0.0",  // Unique name — isolates your cluster
   },
-}
+};
 ```
 
 When `local.enabled` is `true`:
+- 🔓 No Algorand wallet is required. Each node generates an ephemeral signing key at startup.
+- 🆓 All inference is served freely. Payment contract steps are skipped entirely.
+- 🔐 Only nodes sharing the same `privateTopic` can communicate.
 
-- **No Algorand wallet is required.** Each node generates an ephemeral keypair at startup used only for P2P message signing.
-- **All inference requests are served freely.** Payment contract steps are skipped entirely.
-- **The network is isolated by topic.** Only nodes sharing the same `privateTopic` value can communicate with each other.
+For single-machine or LAN setups you can omit `libp2pBootstrapServers` entirely and rely on mDNS auto-discovery.
 
-> **Choose a unique `privateTopic`** for your deployment. A descriptive name (e.g. `"acme-corp/models/1.0.0"`) avoids accidental collisions with other private networks.
+> ⚠️ **Use a unique `privateTopic`.** GossipSub subscription names are transmitted in plaintext over any shared connections. A descriptive, unique value (e.g. `acme-corp/models/1.0.0`) avoids accidental overlap with other networks. Do not use the public DIIISCO bootstrap servers on a private network.
 
-### Bootstrap servers on a private network
+---
 
-Use your own bootstrap server rather than the public Diiisco ones. You can run any Diiisco node as a bootstrap server, just take note of its multiaddr from the startup log and add it to `libp2pBootstrapServers` on your other nodes. For a single local LAN, you can leave `libp2pBootstrapServers` empty and rely on mDNS discovery instead.
+## 📖 Configuration reference
 
-> **Do not use the public Diiisco bootstrap servers on a private network.** GossipSub subscription announcements are transmitted in plaintext, which means any peer you connect to can see the `privateTopic` name your nodes are subscribed to. A node running modified software could then subscribe to the same topic and join your network. Message signatures prevent forgery, but they do not prevent eavesdropping or participation by rogue nodes that have learned your topic name.
+### `peerIdStorage`
+
+| Field | Description |
+|---|---|
+| `path` | Directory where `diiisco-peer-id.protobuf` is stored. This file is your node's persistent libp2p identity — back it up. |
+
+### `models`
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `true` | Whether this node provides inference to the network |
+| `baseURL` | `http://localhost` | Base URL of your LLM backend |
+| `port` | `11434` | Port of your LLM backend (Ollama default) |
+| `apiKey` | `""` | API key for the LLM backend, if required |
+| `chargePer1MTokens` | — | USDC price per 1M tokens. `default` applies to all models; add per-model keys to override |
+
+### `algorand` (public network only)
+
+| Field | Description |
+|---|---|
+| `addr` | Your Algorand wallet address |
+| `mnemonic` | Your 25-word mnemonic passphrase |
+| `network` | `"mainnet"` or `"testnet"` |
+| `client.address` | Algod API endpoint |
+| `client.port` | Algod API port |
+| `client.token` | Algod API token (empty for public nodes) |
+| `nfd` | Optional `.diiisco.algo` NFD domain for verified on-chain identity |
+
+On startup, the node automatically opts into the DSCO and USDC assets and registers with the DIIISCO smart contract if not already done. This requires a small ALGO balance for transaction fees and box storage.
+
+### `api`
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `true` | Whether to start the HTTP API server |
+| `bearerAuthentication` | `true` | Require `Authorization: Bearer <key>` on API requests |
+| `keys` | `[]` | Accepted bearer tokens |
+| `port` | `8080` | Port for the HTTP API |
+| `networkWaitTime` | `10000` | How long (ms) the `/network` endpoint waits for peer responses before returning |
+
+### `quoteEngine`
+
+| Field | Default | Description |
+|---|---|---|
+| `waitTime` | `1000` | How long (ms) to collect quotes before selecting the best one |
+| `quoteSelectionFunction` | `selectHighestStakeQuote` | Strategy used to choose among received quotes |
+| `quoteCreationFunction` | `[createQuoteFromInputTokens]` | How the node prices its own quotes |
+| `preferSelf` | `true` | If `true` and the requested model is available locally, serve it directly without broadcasting to the network |
+
+**Quote selection strategies:**
+
+- `selectHighestStakeQuote` — prefers providers with the most DSCO staked (default, public network)
+- `selectFirstQuote` — takes the first quote received (default in local mode)
+
+### `node`
+
+| Field | Description |
+|---|---|
+| `url` | Publicly reachable URL of this node (used in log output) |
+| `port` | TCP port for libp2p peer-to-peer connections (default: `4242`) |
+| `displayName` | Human-readable name shown on the `/network` endpoint |
+
+### `local`
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Disables Algorand payments and isolates the network to `privateTopic` |
+| `privateTopic` | `diiisco/models/1.0.0` | GossipSub topic name. Must match across all nodes in the cluster |
+
+### `libp2pBootstrapServers`
+
+A list of known peers used to join the network on startup. Accepts multiaddrs directly (`/ip4/…/tcp/…/p2p/…`) or `.diiisco.algo` NFD names that resolve to a multiaddr. Leave empty on a LAN to use mDNS auto-discovery instead.
+
+### 🪪 Verified identity with NFD
+
+[NFD (Non-Fungible Domains)](https://app.nf.domains) is an Algorand naming service. Setting `algorand.nfd` to a `.diiisco.algo` subdomain links your node to a human-readable, on-chain identity that other nodes can verify. Your NFD record must contain a custom property `diiiscohost` set to your full libp2p multiaddr:
+
+```
+/dns4/mynode.example.com/tcp/4242/p2p/<your-peer-id>
+```
+
+If NFD verification fails at startup, the node operates normally — peers will see an unverified identity.
+
+---
+
+## 🚀 Running the node
+
+**Development / one-off:**
+
+```bash
+npm run serve
+```
+
+Builds the project and starts the node in a single step.
+
+**Production (PM2):**
+
+```bash
+npm run node:start    # Build and start as a background service
+npm run node:status   # Check running status
+npm run node:logs     # Tail recent logs
+npm run node:monit    # Live resource monitor
+npm run node:restart  # Rebuild and restart
+npm run node:stop     # Stop the service
+```
+
+---
+
+## 🔌 API reference
+
+Every DIIISCO node exposes an OpenAI-compatible REST API. Point any OpenAI client or SDK at `http://your-node:8080` to use it as a drop-in backend.
+
+When `api.bearerAuthentication` is `true`, all `/v1` and management endpoints require:
+
+```
+Authorization: Bearer <your-key>
+```
+
+### 🤖 Inference
+
+#### `POST /v1/chat/completions`
+
+Standard OpenAI chat completions endpoint. Accepts `messages` or `inputs`.
+
+```bash
+curl http://localhost:8080/v1/chat/completions \
+  -H "Authorization: Bearer sk-your-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "llama3:8b", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+#### `GET /v1/models`
+
+Returns a list of models available across the network.
+
+```bash
+curl http://localhost:8080/v1/models \
+  -H "Authorization: Bearer sk-your-key"
+```
+
+### 🌍 Network
+
+#### `GET /network`
+
+Returns information about all reachable nodes. Waits `api.networkWaitTime` milliseconds for responses before returning.
+
+```bash
+curl http://localhost:8080/network \
+  -H "Authorization: Bearer sk-your-key"
+```
+
+#### `GET /peers`
+
+Returns the list of currently connected libp2p peers.
+
+```bash
+curl http://localhost:8080/peers \
+  -H "Authorization: Bearer sk-your-key"
+```
+
+### 💚 Health
+
+#### `GET /health`
+
+Returns `200 API is healthy`. No authentication required. Suitable for load balancer health checks.
+
+#### `GET /health/algorand`
+
+Returns the Algorand wallet and contract registration status. Returns `200` when everything is healthy, `503` when the node is not ready to participate in paid inference.
+
+```json
+{
+  "localMode": false,
+  "address": "XXXX...",
+  "appId": 3357935482,
+  "algodReachable": true,
+  "algoBalance": "13.269000 ALGO",
+  "dsco": { "optedIn": true, "balance": "463414" },
+  "usdc": { "optedIn": true, "balance": "2.940801 USDC" },
+  "contractRegistered": true
+}
+```
+
+A `503` with `contractRegistered: false` means the wallet hasn't registered with the DIIISCO smart contract — typically caused by insufficient ALGO balance at first startup.
+
+---
+
+## 🧩 Embedding DIIISCO in your application
+
+The node can be imported as a library rather than run as a standalone process:
+
+```typescript
+import { Application, configureEnvironment } from 'diiisco-node';
+
+configureEnvironment({
+  models: { enabled: false },
+  api: { port: 9090 },
+});
+
+const app = new Application();
+await app.start();
+```
+
+Call `configureEnvironment` before constructing `Application`. Settings are deep-merged with the defaults in `environment.ts`.
+
+---
+
+<p align="center">
+  <a href="https://diiisco.com">🌐 DIIISCO.com</a> &nbsp;·&nbsp;
+  <a href="https://diiisco.com/docs/welcome">📖 Docs</a> &nbsp;·&nbsp;
+  <a href="https://x.com/diiiscohq">𝕏 @diiiscohq</a> &nbsp;·&nbsp;
+  <a href="https://discord.gg/WcuuVcrHFa">💬 Discord</a>
+</p>

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -7,14 +7,14 @@ import { EventEmitter } from 'events';
 import { encode } from "msgpackr";
 import { QuoteRequest, QuoteAccepted, InferenceResponse, QuoteResponse, ListModelsResponse, ListModelsRequest, ListNetworkRequest, NetworkNode } from "../types/messages";
 import { logger } from '../utils/logger';
-import { waitForMesh } from '../libp2p/node';
 import { Libp2p } from '@libp2p/interface';
+import { MeshMessageQueue } from '../messaging/meshMessageQueue';
 import { Connection } from 'libp2p-tcp';
 import algorand from '../utils/algorand';
 import { MessageRouter } from '../messaging/messageRouter';
 import { OpenAIInferenceModel } from '../utils/models';
 
-export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: algorand, messageRouter: MessageRouter, model?: OpenAIInferenceModel, availableModels?: string[]) => {
+export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: algorand, messageRouter: MessageRouter, meshQueue: MeshMessageQueue, model?: OpenAIInferenceModel, availableModels?: string[]) => {
   const app = express();
   const port = environment.api.port || 8080;
   app.use(cors());
@@ -24,10 +24,22 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
     app.use("/v1", requireBearer);
     app.use("/peers", requireBearer);
     app.use("/network", requireBearer);
+    app.use("/health/algorand", requireBearer);
   }
 
   app.get('/health', (req, res) => {
     res.status(200).send('API is healthy');
+  });
+
+  app.get('/health/algorand', async (req, res) => {
+    try {
+      const diagnostics = await algo.getDiagnostics();
+      const ok = diagnostics.localMode
+        || (diagnostics.algodReachable && diagnostics.contractRegistered);
+      res.status(ok ? 200 : 503).json(diagnostics);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
   });
 
   app.get('/peers', async (req, res) => {
@@ -63,8 +75,7 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
       };
       networkListMessage.signature = await algo.signObject(networkListMessage);
 
-      waitForMesh(node, environment.local?.privateTopic ?? 'diiisco/models/1.0.0', { min: environment.local?.enabled ? 0 : 1, timeoutMs: 5000 }).then(async () => {
-        await messageRouter.sendMessage(networkListMessage);
+      meshQueue.enqueue(networkListMessage).then(() => {
         logger.info(`📤 Published message to 'diiisco/models/1.0.0'. ID: ${networkListMessage.id}`);
 
         setTimeout(() => {
@@ -74,9 +85,9 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
             "data": nodes,
           });
         }, waitTime);
-      }).catch((err: string) => {
+      }).catch((err: Error) => {
         nodeEvents.off('network-node-received', onNodeReceived);
-        logger.error(`❌ Error waiting for mesh before publishing: ${err}`);
+        logger.error(`❌ Error dispatching network list message: ${err}`);
         return res.status(500).send({ error: "No peers available to handle the request." });
       });
     } catch (error) {
@@ -103,11 +114,10 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
 
       modelListMessage.signature = await algo.signObject(modelListMessage);
 
-      waitForMesh(node, environment.local?.privateTopic ?? 'diiisco/models/1.0.0', { min: environment.local?.enabled ? 0 : 1, timeoutMs: 5000 }).then(async () => {
-        await messageRouter.sendMessage(modelListMessage);
+      meshQueue.enqueue(modelListMessage).then(() => {
         logger.info(`📤 Published message to 'diiisco/models/1.0.0'. ID: ${modelListMessage.id}`);
-      }).catch((err: string) => {
-        logger.error(`❌ Error waiting for mesh before publishing: ${err}`);
+      }).catch((err: Error) => {
+        logger.error(`❌ Error dispatching model list message: ${err}`);
         return res.status(500).send({ error: "No peers available to handle the request." });
       });
     } catch (error) {
@@ -148,11 +158,10 @@ export const createApiServer = (node: Libp2p, nodeEvents: EventEmitter, algo: al
 
     quoteMessage.signature = await algo.signObject(quoteMessage);
 
-    waitForMesh(node, environment.local?.privateTopic ?? 'diiisco/models/1.0.0', { min: environment.local?.enabled ? 0 : 1, timeoutMs: 5000 }).then(async () => {
-      await messageRouter.sendMessage(quoteMessage);
+    meshQueue.enqueue(quoteMessage).then(() => {
       logger.info(`📤 Published message to 'diiisco/models/1.0.0'. ID: ${quoteMessage.id}`);
-    }).catch((err: string) => {
-      logger.error(`❌ Error waiting for mesh before publishing: ${err}`);
+    }).catch((err: Error) => {
+      logger.error(`❌ Error dispatching quote request: ${err}`);
       return res.status(500).send({ error: "No peers available to handle the request." });
     });
 

--- a/src/environment/example.environment.ts
+++ b/src/environment/example.environment.ts
@@ -35,7 +35,8 @@ const environment: Environment = {
       "sk-testkey1",                        // API keys for client authentication
       "sk-testkey2"
     ],
-    port: 8080
+    port: 8080,
+    networkWaitTime: 10000,                 // Time to wait for network responses before timing out (ms)
   },
   quoteEngine: {
     waitTime: 1000,                         // Time to collect quotes before selecting one (ms)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import { logger } from './utils/logger';
 import { DirectMessagingHandler } from './messaging/directMessaging';
 import { MessageRouter } from './messaging/messageRouter';
 import { MessageProcessor } from './messaging/messageProcessor';
+import { MeshReadinessMonitor } from './libp2p/meshReadinessMonitor';
+import { MeshMessageQueue } from './messaging/meshMessageQueue';
 import { decode } from 'msgpackr';
 import { PubSubMessage } from './types/messages';
 import { DEFAULT_DIRECT_MESSAGING_CONFIG } from './utils/defaults';
@@ -136,9 +138,14 @@ class Application extends EventEmitter {
     this.node.services.pubsub.subscribe(topic);
     this.topics.push(topic);
 
+    // Event-driven mesh readiness — replaces per-request waitForMesh polling
+    const meshMin = this.env.local?.enabled ? 0 : 1;
+    const meshMonitor = new MeshReadinessMonitor(this.node, topic, meshMin);
+    const meshQueue = new MeshMessageQueue(meshMonitor, this.messageRouter!);
+
     // Start the API Server
     if (this.env.api.enabled) {
-      const { server } = createApiServer(this.node, this, this.algo, this.messageRouter, this.model, this.availableModels);
+      const { server } = createApiServer(this.node, this, this.algo, this.messageRouter!, meshQueue, this.model, this.availableModels);
       this.apiServer = server;
     }
 

--- a/src/libp2p/meshReadinessMonitor.ts
+++ b/src/libp2p/meshReadinessMonitor.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'events';
+import { logger } from '../utils/logger';
+
+export class MeshReadinessMonitor extends EventEmitter {
+  private _ready: boolean = false;
+  private _intervalId: ReturnType<typeof setInterval>;
+
+  constructor(private _node: any, private _topic: string, private _min: number = 1) {
+    super();
+    // Deferred initial check: let pubsub settle before first evaluation
+    setTimeout(() => this._updateState(), 100);
+    // Re-evaluate shortly after a peer connects (subscription announcements trail the connection)
+    _node.addEventListener('peer:connect', () => setTimeout(() => this._updateState(), 500));
+    _node.addEventListener('peer:disconnect', () => this._updateState());
+    // Background heartbeat catches subscription changes not surfaced by peer events
+    this._intervalId = setInterval(() => this._updateState(), 1000);
+  }
+
+  private _updateState(): void {
+    const count = this._node.services.pubsub.getSubscribers(this._topic).length;
+    const nowReady = count >= this._min;
+    if (nowReady && !this._ready) {
+      this._ready = true;
+      logger.info(`✅ Mesh ready on topic "${this._topic}" (${count} subscriber(s))`);
+      this.emit('ready');
+    } else if (!nowReady && this._ready) {
+      this._ready = false;
+      logger.warn(`⚠️  Mesh degraded on topic "${this._topic}" (${count} subscriber(s))`);
+      this.emit('degraded');
+    }
+  }
+
+  isReady(): boolean {
+    return this._ready;
+  }
+
+  stop(): void {
+    clearInterval(this._intervalId);
+  }
+}

--- a/src/libp2p/peerIdManager.ts
+++ b/src/libp2p/peerIdManager.ts
@@ -5,6 +5,7 @@ import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import type { PrivateKey } from '@libp2p/interface'
 import type { PeerId } from '@libp2p/interface'
 import environment from '../environment/environment'
+import { logger } from '../utils/logger'
 
 /**
  * Utility class for managing persistent libp2p peer IDs
@@ -33,45 +34,45 @@ export class PeerIdManager {
     const filePath = `${sanitizedPath}/${fileName}`;
     
     if (existsSync(filePath)) {
-      console.log(`📁 Loading existing private key from ${filePath}`)
+      logger.info(`📁 Loading existing private key from ${filePath}`)
       try {
         // Read the protobuf private key bytes from file
         const keyBytes = await readFile(filePath)
-        
+
         // Reconstruct the private key from the protobuf bytes
         privateKey = await privateKeyFromProtobuf(keyBytes)
-        
+
         // Create peer ID from the private key
         peerId = peerIdFromPrivateKey(privateKey)
-        
-        console.log(`📋 Loaded peer ID: ${peerId.toString()}`)
+
+        logger.info(`📋 Loaded peer ID: ${peerId.toString()}`)
       } catch (err: any) {
-        console.log('Error loading private key:', err)
-        console.log(`⚠️  Failed to load private key, creating new one: ${err.message}`)
-        
+        logger.error('Error loading private key:', err)
+        logger.warn(`⚠️  Failed to load private key, creating new one: ${err.message}`)
+
         // Fall back to creating a new key
         privateKey = await generateKeyPair('Ed25519')
         peerId = peerIdFromPrivateKey(privateKey)
-        
-        console.log(`🆕 Generated new peer ID: ${peerId.toString()}`)
+
+        logger.info(`🆕 Generated new peer ID: ${peerId.toString()}`)
       }
     } else {
-      console.log(`🆕 Creating new private key and saving to ${filePath}`)
-      
+      logger.info(`🆕 Creating new private key and saving to ${filePath}`)
+
       // Generate new private key
       privateKey = await generateKeyPair('Ed25519')
       peerId = peerIdFromPrivateKey(privateKey)
-      
-      console.log(`🆕 Generated new peer ID: ${peerId.toString()}`)
+
+      logger.info(`🆕 Generated new peer ID: ${peerId.toString()}`)
     }
 
     try {
       // Save the protobuf private key bytes to file
       const keyBytes = privateKeyToProtobuf(privateKey)
       await writeFile(filePath, keyBytes)
-      console.log(`💾 Private key saved to ${filePath}`)
+      logger.info(`💾 Private key saved to ${filePath}`)
     } catch (err: any) {
-      console.log(`⚠️  Failed to save private key: ${err.message}`)
+      logger.warn(`⚠️  Failed to save private key: ${err.message}`)
     }
 
     return { peerId, privateKey }

--- a/src/messaging/meshMessageQueue.ts
+++ b/src/messaging/meshMessageQueue.ts
@@ -1,0 +1,69 @@
+import { PubSubMessage } from '../types/messages';
+import { MessageRouter } from './messageRouter';
+import { MeshReadinessMonitor } from '../libp2p/meshReadinessMonitor';
+import { logger } from '../utils/logger';
+
+interface QueueEntry {
+  message: PubSubMessage;
+  targetPeerId?: string;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  expires: number;
+}
+
+export class MeshMessageQueue {
+  private _queue: QueueEntry[] = [];
+  private _expireIntervalId: ReturnType<typeof setInterval>;
+
+  constructor(
+    private _monitor: MeshReadinessMonitor,
+    private _router: MessageRouter,
+    private _ttlMs: number = 8000
+  ) {
+    _monitor.on('ready', () => this._drain());
+    // Reject stale entries that outlive the TTL without the mesh recovering
+    this._expireIntervalId = setInterval(() => this._expireStale(), 1000);
+  }
+
+  async enqueue(message: PubSubMessage, targetPeerId?: string): Promise<void> {
+    if (this._monitor.isReady()) {
+      await this._router.sendMessage(message, targetPeerId);
+      return;
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      this._queue.push({ message, targetPeerId, resolve, reject, expires: Date.now() + this._ttlMs });
+      logger.debug(`📥 Queued ${message.role} (mesh not ready, TTL ${this._ttlMs}ms)`);
+    });
+  }
+
+  private async _drain(): Promise<void> {
+    const entries = this._queue.splice(0);
+    const now = Date.now();
+    for (const entry of entries) {
+      if (entry.expires <= now) {
+        entry.reject(new Error(`Mesh not ready: TTL expired for "${entry.message.role}"`));
+        continue;
+      }
+      try {
+        await this._router.sendMessage(entry.message, entry.targetPeerId);
+        entry.resolve();
+      } catch (err: any) {
+        entry.reject(err);
+      }
+    }
+  }
+
+  private _expireStale(): void {
+    const now = Date.now();
+    const stale = this._queue.filter(e => e.expires <= now);
+    this._queue = this._queue.filter(e => e.expires > now);
+    for (const e of stale) {
+      e.reject(new Error(`Mesh not ready: TTL expired for "${e.message.role}"`));
+    }
+  }
+
+  stop(): void {
+    clearInterval(this._expireIntervalId);
+  }
+}

--- a/src/messaging/messageProcessor.ts
+++ b/src/messaging/messageProcessor.ts
@@ -241,10 +241,6 @@ export class MessageProcessor {
 
   private async handleQuoteAccepted(msg: QuoteAccepted, sourcePeerId: string) {
     if (this.env.local?.enabled || sourcePeerId === this.ownPeerId) {
-      // Skip the contract round-trips and run inference directly:
-      // - local mode: payments are disabled network-wide
-      // - self-request: same node is both client and provider; the payment
-      //   contract cannot have the same Algorand address as both customer and provider
       await this.executeInference(msg, sourcePeerId);
       return;
     }
@@ -323,7 +319,7 @@ export class MessageProcessor {
   private async handleInferenceResponse(msg: InferenceResponse, sourcePeerId: string) {
     logger.info(`📥 Received inference-response from ${sourcePeerId}`);
     let payment: number | null = null;
-    if (!this.env.local?.enabled) {
+    if (!this.env.local?.enabled && sourcePeerId !== this.ownPeerId) {
       payment = await this.algo.completeQuote({
         quoteId: msg.id,
         provider: Address.fromString(msg.fromWalletAddr)

--- a/src/utils/algorand.ts
+++ b/src/utils/algorand.ts
@@ -617,6 +617,48 @@ export default class algorand {
   isValidAddress(addr: string): boolean {
     return algosdk.isValidAddress(addr);
   }
+
+  async getDiagnostics(): Promise<{
+    localMode: boolean;
+    address?: string;
+    appId?: number;
+    algodReachable: boolean;
+    algoBalance?: string;
+    dsco?: { optedIn: boolean; balance: string };
+    usdc?: { optedIn: boolean; balance: string };
+    contractRegistered?: boolean;
+    error?: string;
+  }> {
+    if (this.env.local?.enabled) {
+      return { localMode: true, algodReachable: false };
+    }
+
+    const address = this.account.addr.toString();
+    const result: Awaited<ReturnType<algorand['getDiagnostics']>> = {
+      localMode: false,
+      address,
+      appId: diiiscoContract.app,
+      algodReachable: false,
+    };
+
+    try {
+      const accountInfo = await this.algod.accountInformation(address).do();
+      result.algodReachable = true;
+      result.algoBalance = (Number(accountInfo.amount) / 1_000_000).toFixed(6) + ' ALGO';
+
+      const dsco = await this.checkIfOptedInToAsset(address, diiiscoContract.asset);
+      result.dsco = { optedIn: dsco.optedIn, balance: dsco.balance.toString() };
+
+      const usdc = await this.checkIfOptedInToAsset(address, diiiscoContract.usdc);
+      result.usdc = { optedIn: usdc.optedIn, balance: (Number(usdc.balance) / 1_000_000).toFixed(6) + ' USDC' };
+
+      result.contractRegistered = await this.checkIfRegistered(address, diiiscoContract.app);
+    } catch (err: any) {
+      result.error = err.message ?? String(err);
+    }
+
+    return result;
+  }
 }
 
 export async function nfdToNodeAddress(addr: string): Promise<string | null> {


### PR DESCRIPTION
🆕 Replaces waitForMesh with a system that automatically monitors the mesh network and queues messages for when the mesh network is ready.
🪲 Fixes a bug with local implementation so that a node does not try to pay itself with a contract that does not exist. 
🪲 Fixes an issue where some of the opening console logs were not being done with the official logger.
🆕 Finally, the readme is updated to have more information.