### PR TITLE
Optional Network Wait Time

### DIFF
--- a/src/environment/environment.types.ts
+++ b/src/environment/environment.types.ts
@@ -36,7 +36,7 @@ export interface ApiConfig {
   bearerAuthentication: boolean;
   keys: string[];
   port: number;
-  networkWaitTime: number;
+  networkWaitTime?: number;
 }
 
 


### PR DESCRIPTION
🪲 Fixes a bug where networkWaitTime is not an optional parameter in the environment.ts api settings.