### PR TITLE
Use Simulate for Algorand Read-Only Operations 

### DIFF
--- a/src/utils/algorand.ts
+++ b/src/utils/algorand.ts
@@ -466,7 +466,7 @@ export default class algorand {
       ],
     });
 
-    const res = await atc.execute(this.algod, 4);
+    const res = await atc.simulate(this.algod);
     const tup = res.methodResults[0].returnValue as [
       Uint8Array,
       Uint8Array,

--- a/src/utils/algorand.ts
+++ b/src/utils/algorand.ts
@@ -519,7 +519,7 @@ export default class algorand {
       ],
     });
 
-    const res = await atc.execute(this.algod, 4);
+    const res = await atc.simulate(this.algod);
     const value = res.methodResults[0].returnValue as [bigint, bigint, bigint];
     const [funded, status, usdcAmount] = value;
 


### PR DESCRIPTION
For read-only operations with smart contract on the Algorand Blockchain the simulate method can be sued which is faster and does not incur fees.