### PR TITLE
P2P Circuit Relay Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "it-pushable": "^3.2.3",
     "js-sha256": "^0.11.1",
     "json-canonicalize": "^2.0.0",
-    "libp2p": "^3.0.6",
+    "libp2p": "^3.3.5",
     "libp2p-tcp": "^0.17.2",
     "llama-tokenizer-js": "^1.2.2",
     "msgpack-lite": "^0.1.26",

--- a/src/environment/environment.types.ts
+++ b/src/environment/environment.types.ts
@@ -55,16 +55,6 @@ export interface PeerIdStorageConfig {
 
 export interface PeerIdConfig extends PeerId.JSONPeerId {}
 
-export interface RelayConfig {
-  enableRelayServer: boolean;
-  autoEnableRelay: boolean;
-  maxRelayedConnections: number;
-  enableRelayClient: boolean;
-  enableDCUtR: boolean;
-  maxDataPerConnection: number;
-  maxRelayDuration: number;
-}
-
 export interface DirectMessagingConfig {
   enabled: boolean;
   timeout: number;
@@ -92,6 +82,5 @@ export interface Environment {
     port?: number;
     displayName?: string;
   };
-  relay?: RelayConfig;  // Optional: uses defaults if not provided
   directMessaging?: DirectMessagingConfig;  // Optional: uses defaults if not provided
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { createLibp2pNode, lookupBootstrapServers } from './libp2p/node';
+import { setLocalAddressProvider } from './libp2p/localAddresses';
 import { ReconnectionDependencies, scheduleReconnect, attemptReconnect, reconnectToBootstrap, startConnectionHealthCheck, stopConnectionHealthCheck } from './libp2p/reconnection';
 import { createApiServer } from './api/server';
 import { EventEmitter } from 'events';
@@ -84,7 +85,11 @@ class Application extends EventEmitter {
     
     // Create and Start the Libp2p Node
     this.node = await createLibp2pNode();
-    
+
+    // Expose our current multiaddrs to the message signer so every outgoing
+    // message advertises how to reach us (incl. relay-circuit addresses).
+    setLocalAddressProvider(() => this.node.getMultiaddrs().map((a: any) => a.toString()));
+
     // Initialize Algorand for DSCO Payments
     await this.algo.initialize(this.node.peerId.toString());
 
@@ -130,7 +135,8 @@ class Application extends EventEmitter {
       this.availableModels,
       this,
       this.messageRouter,
-      this.node.peerId.toString()
+      this.node.peerId.toString(),
+      this.node
     );
 
     // Create a Relay PubSub Topic

--- a/src/libp2p/localAddresses.ts
+++ b/src/libp2p/localAddresses.ts
@@ -1,0 +1,30 @@
+/**
+ * Small decoupled registry for the local node's current multiaddrs.
+ *
+ * The message-signing chokepoint (`algorand.signObject`) needs to stamp our
+ * current addresses onto every outgoing message so peers can dial us over a
+ * relay circuit without a DHT lookup. Rather than couple the Algorand utility
+ * to libp2p, the Application registers a provider here once the node is up.
+ */
+let provider: (() => string[]) | null = null;
+
+/**
+ * Register a function that returns the local node's current multiaddrs as
+ * strings. Called once at startup after the libp2p node is created.
+ */
+export const setLocalAddressProvider = (fn: () => string[]): void => {
+  provider = fn;
+};
+
+/**
+ * Get the local node's current multiaddrs. Returns an empty array if no
+ * provider has been registered yet (e.g. before the node has started).
+ */
+export const getLocalMultiaddrs = (): string[] => {
+  if (!provider) return [];
+  try {
+    return provider();
+  } catch {
+    return [];
+  }
+};

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -16,7 +16,10 @@ import { PeerIdManager } from './peerIdManager';
 import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
 import environment from '../environment/environment';
 import { nfdToNodeAddress } from '../utils/algorand';
-import { DEFAULT_RELAY_CONFIG } from '../utils/defaults';
+
+// Maximum circuit-relay reservations a public relay node will accept from
+// NAT'd peers. Only relevant when this node runs the relay server.
+const MAX_RELAY_RESERVATIONS = 200;
 
 export const lookupBootstrapServers = async (): Promise<string[]> => {
   // No Bootstrap Servers Configured
@@ -37,9 +40,6 @@ export const lookupBootstrapServers = async (): Promise<string[]> => {
 };
 
 export const createLibp2pNode = async () => {
-  // Get relay config with defaults
-  const relayConfig = environment.relay || DEFAULT_RELAY_CONFIG;
-
   // Load or Create a Peer ID
   const peer = await PeerIdManager.loadOrCreate('diiisco-peer-id.protobuf');
 
@@ -124,19 +124,17 @@ export const createLibp2pNode = async () => {
       // AutoNAT for detecting reachability
       autoNAT: autoNAT(),
 
-      // Circuit Relay Server (if enabled)
+      // Circuit Relay Server — only public nodes accept reservations
       ...(isPublicNode ? {
         relay: circuitRelayServer({
           reservations: {
-            maxReservations: relayConfig.maxRelayedConnections * 2,
+            maxReservations: MAX_RELAY_RESERVATIONS,
           },
         })
       } : {}),
 
-      // DCUtR for connection upgrade (if enabled)
-      ...(relayConfig.enableDCUtR ? {
-        dcutr: dcutr()
-      } : {}),
+      // DCUtR — upgrade relayed connections to direct when possible
+      dcutr: dcutr(),
     }
   });
 
@@ -149,14 +147,11 @@ export const createLibp2pNode = async () => {
   await node.start()
   logger.info('✅ Node started with id:', node.peerId.toString());
 
-  // Log relay/client role so it's immediately clear on startup
-  if (relayConfig.enableRelayServer) {
+  // Log relay role so it's immediately clear on startup
+  if (isPublicNode) {
     logger.info('🛰️  Circuit relay server: ENABLED (will accept reservations from private nodes)');
   } else {
-    logger.info('🛰️  Circuit relay server: DISABLED');
-  }
-  if (relayConfig.enableRelayClient) {
-    logger.info('🔗 Circuit relay client: ENABLED (will seek relay reservations if behind NAT)');
+    logger.info('🔗 Circuit relay client: ENABLED (will seek relay reservations behind NAT)');
   }
 
   // Show Connection Details
@@ -175,7 +170,7 @@ export const createLibp2pNode = async () => {
 
     if (publicAddrs.length > 0) {
       logger.info(`🌐 Node is publicly reachable: ${publicAddrs.map((a: any) => a.toString()).join(', ')}`);
-      if (relayConfig.enableRelayServer) {
+      if (isPublicNode) {
         logger.info('🌐 Relay server active — accepting reservations from private nodes');
       }
     } else if (relayAddrs.length > 0) {

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -159,10 +159,15 @@ export const createLibp2pNode = async () => {
         relay: circuitRelayServer({
           reservations: {
             maxReservations: MAX_RELAY_RESERVATIONS,
-            // Lift the default 128KB / 2-minute cap on relayed connections —
-            // inference responses can be large and must survive the relay path
-            // (DCUtR still upgrades to a direct connection where it can).
-            applyDefaultLimit: false,
+            // Bound relayed connections to the OpenAI API envelope rather than
+            // libp2p's tiny 128KB / 2-min default (which truncates real
+            // completions) or an unlimited relay (which invites abuse):
+            //  - 10 min: the OpenAI SDK default request timeout.
+            //  - 25 MB: OpenAI's documented max content size (26,214,400 bytes),
+            //    ample for any completion while capping relay abuse.
+            // DCUtR still upgrades heavy traffic to a direct connection off the relay.
+            defaultDurationLimit: 10 * 60 * 1000,
+            defaultDataLimit: BigInt(25 * 1024 * 1024),
           },
         })
       } : {}),

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -10,106 +10,17 @@ import { kadDHT } from '@libp2p/kad-dht';
 import { autoNAT } from '@libp2p/autonat';
 import { circuitRelayServer, circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { dcutr } from '@libp2p/dcutr';
-import { isPrivate, lpStream } from '@libp2p/utils';
+import { isPrivate } from '@libp2p/utils';
 import { FaultTolerance } from '@libp2p/interface';
 import { logger } from '../utils/logger';
-import { enable as enableLibp2pLogs } from '@libp2p/logger';
 import { PeerIdManager } from './peerIdManager';
 import { bootstrap } from '@libp2p/bootstrap';
-import { peerIdFromString } from '@libp2p/peer-id';
 import environment from '../environment/environment';
 import { nfdToNodeAddress } from '../utils/algorand';
 
 // Maximum circuit-relay reservations a public relay node will accept from
 // NAT'd peers. Only relevant when this node runs the relay server.
 const MAX_RELAY_RESERVATIONS = 200;
-
-// Protocol a relay server advertises when it can accept reservations. If a
-// bootstrap relay does not speak this, no reservation is possible.
-const RELAY_HOP_PROTOCOL = '/libp2p/circuit/relay/0.2.0/hop';
-
-// Circuit-relay-v2 HOP status codes (see the pb Status enum).
-const HOP_STATUS_NAMES: Record<number, string> = {
-  100: 'OK',
-  200: 'RESERVATION_REFUSED',
-  201: 'RESOURCE_LIMIT_EXCEEDED',
-  202: 'PERMISSION_DENIED',
-  203: 'CONNECTION_FAILED',
-  204: 'NO_RESERVATION',
-  400: 'MALFORMED_MESSAGE',
-  401: 'UNEXPECTED_MESSAGE',
-};
-
-// Read a protobuf varint from buf starting at pos; returns [value, nextPos].
-function readVarint(buf: Uint8Array, pos: number): [number, number] {
-  let result = 0;
-  let shift = 0;
-  let p = pos;
-  while (p < buf.length) {
-    const b = buf[p++];
-    result |= (b & 0x7f) << shift;
-    if ((b & 0x80) === 0) break;
-    shift += 7;
-  }
-  return [result >>> 0, p];
-}
-
-// Minimal top-level parse of a HopMessage response — we only need the status
-// (field 5, varint) and whether a reservation (field 3) was returned.
-function parseHopResponse(buf: Uint8Array): { status?: number; hasReservation: boolean } {
-  let pos = 0;
-  let status: number | undefined;
-  let hasReservation = false;
-  while (pos < buf.length) {
-    const [tag, p1] = readVarint(buf, pos);
-    pos = p1;
-    const field = tag >>> 3;
-    const wire = tag & 0x7;
-    if (wire === 0) {
-      const [val, p2] = readVarint(buf, pos);
-      pos = p2;
-      if (field === 5) status = val;
-    } else if (wire === 2) {
-      const [len, p2] = readVarint(buf, pos);
-      pos = p2 + len;
-      if (field === 3) hasReservation = true;
-    } else if (wire === 1) {
-      pos += 8;
-    } else if (wire === 5) {
-      pos += 4;
-    } else {
-      break;
-    }
-  }
-  return { status, hasReservation };
-}
-
-/**
- * Directly ask a relay for a reservation and log the exact status via our own
- * logger. Replicates what circuitRelayTransport does internally, but surfaces
- * the relay's answer (which libp2p otherwise only reports through debug logs)
- * so we can tell a relay-side refusal from a client-side wiring problem.
- */
-async function probeRelayReservation(node: any, relayPeerId: any): Promise<void> {
-  const relayIdShort = relayPeerId.toString().slice(0, 16);
-  try {
-    const stream = await node.dialProtocol(relayPeerId, RELAY_HOP_PROTOCOL, { signal: AbortSignal.timeout(10000) });
-    const lp = lpStream(stream);
-    // HopMessage { type: RESERVE } — field 1 (tag 0x08), enum RESERVE = 0.
-    await lp.write(Uint8Array.from([0x08, 0x00]));
-    const data = await lp.read({ signal: AbortSignal.timeout(10000) });
-    const { status, hasReservation } = parseHopResponse(data.subarray());
-    const name = status != null ? (HOP_STATUS_NAMES[status] ?? `code ${status}`) : 'unknown';
-    if (status === 100) {
-      logger.info(`🔬 Reservation probe to ${relayIdShort}... → ${name}${hasReservation ? ' (reservation granted)' : ' (OK but no reservation body)'} — relay accepts us; issue is client-side wiring`);
-    } else {
-      logger.warn(`🔬 Reservation probe to ${relayIdShort}... → ${name} — the relay refused the reservation`);
-    }
-    await lp.unwrap().close().catch(() => {});
-  } catch (err: any) {
-    logger.warn(`🔬 Reservation probe to ${relayIdShort}... failed before a status was returned: ${err?.message ?? err}`);
-  }
-}
 
 export const lookupBootstrapServers = async (): Promise<string[]> => {
   // No Bootstrap Servers Configured
@@ -130,18 +41,6 @@ export const lookupBootstrapServers = async (): Promise<string[]> => {
 };
 
 export const createLibp2pNode = async () => {
-  // Surface libp2p's own circuit-relay *errors* (only the :error namespaces, so
-  // no trace spam) via stderr. On a private node these show why a reservation
-  // failed; on the relay, `…:server:error` prints "failed to send confirmation
-  // response … - <err>" — the reason a RESERVE gets no reply. These bypass our
-  // logger, so check stderr (PM2 error log / `npm run node:logs`).
-  enableLibp2pLogs([
-    'libp2p:circuit-relay:transport:reservation-store:error',
-    'libp2p:circuit-relay:transport:listener:error',
-    'libp2p:circuit-relay:server:error',
-    'libp2p:circuit-relay:server:reservation-store:error',
-  ].join(','));
-
   // Load or Create a Peer ID
   const peer = await PeerIdManager.loadOrCreate('diiisco-peer-id.protobuf');
 
@@ -299,65 +198,11 @@ export const createLibp2pNode = async () => {
   // In libp2p v3, AutoNAT works by confirming/removing observed addresses rather than
   // setting a reachability metadata key. We infer reachability by filtering getMultiaddrs().
   node.addEventListener('self:peer:update', () => {
-    const allAddrs = node.getMultiaddrs();
-    const publicAddrs = allAddrs.filter((a: any) => !isPrivate(a) && !a.toString().includes('p2p-circuit'));
-    const relayAddrs = allAddrs.filter((a: any) => a.toString().includes('p2p-circuit'));
-
-    if (publicAddrs.length > 0) {
+    const publicAddrs = node.getMultiaddrs().filter((a: any) => !isPrivate(a) && !a.toString().includes('p2p-circuit'));
+    if (publicAddrs.length > 0 && isPublicNode) {
       logger.info(`🌐 Node is publicly reachable: ${publicAddrs.map((a: any) => a.toString()).join(', ')}`);
-      if (isPublicNode) {
-        logger.info('🌐 Relay server active — accepting reservations from private nodes');
-      }
-    } else if (relayAddrs.length > 0) {
-      logger.info(`🔗 Relay reservation established — reachable via:`);
-      relayAddrs.forEach((a: any) => logger.info(`   ${a.toString()}`));
-    } else {
-      logger.info('🔒 No public or relay addresses yet — waiting for relay reservation');
     }
   });
-
-  // After identify has run, report whether each configured relay actually
-  // advertises the circuit-relay HOP protocol. If it doesn't, the relay is not
-  // running as a relay server and no reservation is possible — which is the
-  // usual reason a private node ends up with zero relay addresses.
-  if (!isPublicNode && relayListenAddrs.length > 0) {
-    setTimeout(async () => {
-      for (const addr of relayListenAddrs) {
-        const relayId = addr.match(/\/p2p\/([^/]+)/)?.[1];
-        if (!relayId) continue;
-        try {
-          const peerIdObj = peerIdFromString(relayId);
-          const connected = node.getConnections(peerIdObj).length > 0;
-          let hasHop = false;
-          try {
-            const relayPeer = await node.peerStore.get(peerIdObj);
-            hasHop = relayPeer.protocols.includes(RELAY_HOP_PROTOCOL);
-          } catch { /* relay not yet in peerstore */ }
-          const reserved = node.getMultiaddrs().some((a: any) => a.toString().includes(`/p2p/${relayId}/p2p-circuit`));
-
-          if (hasHop) {
-            logger.info(`🛰️  Relay ${relayId.slice(0, 16)}... advertises HOP [connected: ${connected}, reservation: ${reserved ? 'established' : 'pending'}]`);
-            // Reservation hasn't landed via the transport — ask the relay
-            // ourselves to capture the exact status.
-            if (!reserved && connected) {
-              await probeRelayReservation(node, peerIdObj);
-            }
-          } else {
-            logger.warn(`⚠️ Relay ${relayId.slice(0, 16)}... does NOT advertise circuit-relay HOP [connected: ${connected}] — it is not running as a relay server, so no reservation is possible`);
-          }
-        } catch { /* invalid relay peer id */ }
-      }
-    }, 8000);
-  }
-
-  // After 30s, log address state so we can confirm relay reservations settled
-  setTimeout(() => {
-    const allAddrs = node.getMultiaddrs();
-    const relayAddrs = allAddrs.filter((a: any) => a.toString().includes('p2p-circuit'));
-    const publicAddrs = allAddrs.filter((a: any) => !isPrivate(a) && !a.toString().includes('p2p-circuit'));
-    logger.info(`📋 Address check (30s): ${allAddrs.length} total — ${publicAddrs.length} public, ${relayAddrs.length} relay circuit`);
-    allAddrs.forEach((a: any) => logger.info(`   ${a.toString()}`));
-  }, 30000);
 
   // Start keep-alive ping loop for connected peers
   startKeepAlive(node);

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -11,15 +11,21 @@ import { autoNAT } from '@libp2p/autonat';
 import { circuitRelayServer, circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { dcutr } from '@libp2p/dcutr';
 import { isPrivate } from '@libp2p/utils';
+import { FaultTolerance } from '@libp2p/interface';
 import { logger } from '../utils/logger';
 import { PeerIdManager } from './peerIdManager';
-import { bootstrap, BootstrapInit } from '@libp2p/bootstrap';
+import { bootstrap } from '@libp2p/bootstrap';
+import { peerIdFromString } from '@libp2p/peer-id';
 import environment from '../environment/environment';
 import { nfdToNodeAddress } from '../utils/algorand';
 
 // Maximum circuit-relay reservations a public relay node will accept from
 // NAT'd peers. Only relevant when this node runs the relay server.
 const MAX_RELAY_RESERVATIONS = 200;
+
+// Protocol a relay server advertises when it can accept reservations. If a
+// bootstrap relay does not speak this, no reservation is possible.
+const RELAY_HOP_PROTOCOL = '/libp2p/circuit/relay/0.2.0/hop';
 
 export const lookupBootstrapServers = async (): Promise<string[]> => {
   // No Bootstrap Servers Configured
@@ -43,12 +49,14 @@ export const createLibp2pNode = async () => {
   // Load or Create a Peer ID
   const peer = await PeerIdManager.loadOrCreate('diiisco-peer-id.protobuf');
 
+  // Resolve bootstrap servers once — reused for both peer discovery and for
+  // building explicit circuit-relay listen addresses.
+  const parsedBootstrapServers = await lookupBootstrapServers();
+
   // Prepare Peer Discovery Modules
   const peerDiscovery: any[] = [mdns()];
 
-  if (environment.libp2pBootstrapServers && environment.libp2pBootstrapServers.length > 0) {
-    const parsedBootstrapServers = await lookupBootstrapServers();
-
+  if (parsedBootstrapServers.length > 0) {
     peerDiscovery.push(bootstrap({
       list: parsedBootstrapServers,
     }));
@@ -61,6 +69,26 @@ export const createLibp2pNode = async () => {
   : null;
   const isPublicNode = publicUrl !== null;
 
+  // For private nodes, listen on an explicit circuit address per bootstrap
+  // relay (e.g. /dns4/relay/tcp/4242/p2p/<relayId>/p2p-circuit). This forces a
+  // reservation on each known relay ('configured' path) instead of relying on
+  // auto-discovery, which is what leaves NAT'd nodes with zero relay addresses.
+  // A bare '/p2p-circuit' is also kept so additional relays can be discovered.
+  const relayListenAddrs = parsedBootstrapServers
+    .filter((addr) => addr.includes('/p2p/'))
+    .map((addr) => `${addr}/p2p-circuit`);
+
+  // Surface which relays we'll try to reserve on — makes it obvious in the logs
+  // whether a private node has a usable relay to fall back on.
+  if (!isPublicNode) {
+    if (relayListenAddrs.length > 0) {
+      logger.info(`🛰️  Requesting relay reservations on ${relayListenAddrs.length} relay(s):`);
+      relayListenAddrs.forEach((addr) => logger.info(`   ${addr}`));
+    } else {
+      logger.warn('⚠️ No bootstrap relays with a /p2p/ peer id — cannot reserve a relay, only bare /p2p-circuit discovery will be attempted');
+    }
+  }
+
   // Create the Libp2p Node with connection management and keep-alive
   const node = await createLibp2p({
     privateKey: peer.privateKey,
@@ -69,11 +97,18 @@ export const createLibp2pNode = async () => {
         // Required for circuitRelayTransport to call reserveRelay() and make
         // relay reservations. Without this entry pendingReservations stays empty
         // and every discovered relay peer is immediately rejected.
-        ...(isPublicNode ? [`/ip4/0.0.0.0/tcp/${port}`] : ['/p2p-circuit']),
+        ...(isPublicNode ? [`/ip4/0.0.0.0/tcp/${port}`] : [...relayListenAddrs, '/p2p-circuit']),
       ],
       // Announce the stable DNS name so relay circuit addresses returned to
       // clients carry the domain rather than a raw IP.
       ...(publicUrl ? { announce: [`/dns4/${publicUrl}/tcp/${port}`] } : {}),
+    },
+    // Private nodes listen on explicit relay-circuit addresses that may fail if
+    // a relay is momentarily unreachable at startup — tolerate that and run
+    // dial-only, letting relay discovery retry. Public nodes keep fatal
+    // behaviour so a failed TCP bind surfaces loudly.
+    transportManager: {
+      faultTolerance: isPublicNode ? FaultTolerance.FATAL_ALL : FaultTolerance.NO_FATAL,
     },
     transports: [
       tcp(),
@@ -180,6 +215,35 @@ export const createLibp2pNode = async () => {
       logger.info('🔒 No public or relay addresses yet — waiting for relay reservation');
     }
   });
+
+  // After identify has run, report whether each configured relay actually
+  // advertises the circuit-relay HOP protocol. If it doesn't, the relay is not
+  // running as a relay server and no reservation is possible — which is the
+  // usual reason a private node ends up with zero relay addresses.
+  if (!isPublicNode && relayListenAddrs.length > 0) {
+    setTimeout(async () => {
+      for (const addr of relayListenAddrs) {
+        const relayId = addr.match(/\/p2p\/([^/]+)/)?.[1];
+        if (!relayId) continue;
+        try {
+          const peerIdObj = peerIdFromString(relayId);
+          const connected = node.getConnections(peerIdObj).length > 0;
+          let hasHop = false;
+          try {
+            const relayPeer = await node.peerStore.get(peerIdObj);
+            hasHop = relayPeer.protocols.includes(RELAY_HOP_PROTOCOL);
+          } catch { /* relay not yet in peerstore */ }
+          const reserved = node.getMultiaddrs().some((a: any) => a.toString().includes(`/p2p/${relayId}/p2p-circuit`));
+
+          if (hasHop) {
+            logger.info(`🛰️  Relay ${relayId.slice(0, 16)}... advertises HOP [connected: ${connected}, reservation: ${reserved ? 'established' : 'pending'}]`);
+          } else {
+            logger.warn(`⚠️ Relay ${relayId.slice(0, 16)}... does NOT advertise circuit-relay HOP [connected: ${connected}] — it is not running as a relay server, so no reservation is possible`);
+          }
+        } catch { /* invalid relay peer id */ }
+      }
+    }, 8000);
+  }
 
   // After 30s, log address state so we can confirm relay reservations settled
   setTimeout(() => {

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -66,11 +66,10 @@ export const createLibp2pNode = async () => {
     privateKey: peer.privateKey,
     addresses: {
       listen: [
-        `/ip4/0.0.0.0/tcp/${port}`,
         // Required for circuitRelayTransport to call reserveRelay() and make
         // relay reservations. Without this entry pendingReservations stays empty
         // and every discovered relay peer is immediately rejected.
-        ...(isPublicNode ? [] : ['/p2p-circuit']),
+        ...(isPublicNode ? [`/ip4/0.0.0.0/tcp/${port}`] : ['/p2p-circuit']),
       ],
       // Announce the stable DNS name so relay circuit addresses returned to
       // clients carry the domain rather than a raw IP.

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -260,6 +260,10 @@ export const createLibp2pNode = async () => {
         relay: circuitRelayServer({
           reservations: {
             maxReservations: MAX_RELAY_RESERVATIONS,
+            // Lift the default 128KB / 2-minute cap on relayed connections —
+            // inference responses can be large and must survive the relay path
+            // (DCUtR still upgrades to a direct connection where it can).
+            applyDefaultLimit: false,
           },
         })
       } : {}),

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -54,16 +54,12 @@ export const createLibp2pNode = async () => {
     }));
   }
 
-  // Prepare transports
-  const transports: any[] = [tcp()];
-  if (relayConfig.enableRelayClient) {
-    transports.push(circuitRelayTransport());
-  }
-
+  //Detect if Public Node
   const port = environment.node?.port || 4242;
   const publicUrl = environment.node?.url && !environment.node.url.includes('localhost') && environment.node.url !== '127.0.0.1'
-    ? environment.node.url
-    : null;
+  ? environment.node.url
+  : null;
+  const isPublicNode = publicUrl !== null;
 
   // Create the Libp2p Node with connection management and keep-alive
   const node = await createLibp2p({
@@ -74,13 +70,16 @@ export const createLibp2pNode = async () => {
         // Required for circuitRelayTransport to call reserveRelay() and make
         // relay reservations. Without this entry pendingReservations stays empty
         // and every discovered relay peer is immediately rejected.
-        ...(relayConfig.enableRelayClient ? ['/p2p-circuit'] : []),
+        ...(isPublicNode ? [] : ['/p2p-circuit']),
       ],
       // Announce the stable DNS name so relay circuit addresses returned to
       // clients carry the domain rather than a raw IP.
       ...(publicUrl ? { announce: [`/dns4/${publicUrl}/tcp/${port}`] } : {}),
     },
-    transports,
+    transports: [
+      tcp(),
+      ...(isPublicNode ? [] : [circuitRelayTransport()]), // Only add circuit relay transport if not a public node
+    ],
     connectionEncrypters: [noise()],
     peerDiscovery,
     streamMuxers: [yamux()],
@@ -127,7 +126,7 @@ export const createLibp2pNode = async () => {
       autoNAT: autoNAT(),
 
       // Circuit Relay Server (if enabled)
-      ...(relayConfig.enableRelayServer ? {
+      ...(isPublicNode ? {
         relay: circuitRelayServer({
           reservations: {
             maxReservations: relayConfig.maxRelayedConnections * 2,
@@ -150,6 +149,16 @@ export const createLibp2pNode = async () => {
   // Start the Libp2p Node
   await node.start()
   logger.info('✅ Node started with id:', node.peerId.toString());
+
+  // Log relay/client role so it's immediately clear on startup
+  if (relayConfig.enableRelayServer) {
+    logger.info('🛰️  Circuit relay server: ENABLED (will accept reservations from private nodes)');
+  } else {
+    logger.info('🛰️  Circuit relay server: DISABLED');
+  }
+  if (relayConfig.enableRelayClient) {
+    logger.info('🔗 Circuit relay client: ENABLED (will seek relay reservations if behind NAT)');
+  }
 
   // Show Connection Details
   logger.info('👂 Listening on:');
@@ -177,6 +186,15 @@ export const createLibp2pNode = async () => {
       logger.info('🔒 No public or relay addresses yet — waiting for relay reservation');
     }
   });
+
+  // After 30s, log address state so we can confirm relay reservations settled
+  setTimeout(() => {
+    const allAddrs = node.getMultiaddrs();
+    const relayAddrs = allAddrs.filter((a: any) => a.toString().includes('p2p-circuit'));
+    const publicAddrs = allAddrs.filter((a: any) => !isPrivate(a) && !a.toString().includes('p2p-circuit'));
+    logger.info(`📋 Address check (30s): ${allAddrs.length} total — ${publicAddrs.length} public, ${relayAddrs.length} relay circuit`);
+    allAddrs.forEach((a: any) => logger.info(`   ${a.toString()}`));
+  }, 30000);
 
   // Start keep-alive ping loop for connected peers
   startKeepAlive(node);

--- a/src/libp2p/node.ts
+++ b/src/libp2p/node.ts
@@ -10,9 +10,10 @@ import { kadDHT } from '@libp2p/kad-dht';
 import { autoNAT } from '@libp2p/autonat';
 import { circuitRelayServer, circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { dcutr } from '@libp2p/dcutr';
-import { isPrivate } from '@libp2p/utils';
+import { isPrivate, lpStream } from '@libp2p/utils';
 import { FaultTolerance } from '@libp2p/interface';
 import { logger } from '../utils/logger';
+import { enable as enableLibp2pLogs } from '@libp2p/logger';
 import { PeerIdManager } from './peerIdManager';
 import { bootstrap } from '@libp2p/bootstrap';
 import { peerIdFromString } from '@libp2p/peer-id';
@@ -26,6 +27,89 @@ const MAX_RELAY_RESERVATIONS = 200;
 // Protocol a relay server advertises when it can accept reservations. If a
 // bootstrap relay does not speak this, no reservation is possible.
 const RELAY_HOP_PROTOCOL = '/libp2p/circuit/relay/0.2.0/hop';
+
+// Circuit-relay-v2 HOP status codes (see the pb Status enum).
+const HOP_STATUS_NAMES: Record<number, string> = {
+  100: 'OK',
+  200: 'RESERVATION_REFUSED',
+  201: 'RESOURCE_LIMIT_EXCEEDED',
+  202: 'PERMISSION_DENIED',
+  203: 'CONNECTION_FAILED',
+  204: 'NO_RESERVATION',
+  400: 'MALFORMED_MESSAGE',
+  401: 'UNEXPECTED_MESSAGE',
+};
+
+// Read a protobuf varint from buf starting at pos; returns [value, nextPos].
+function readVarint(buf: Uint8Array, pos: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  let p = pos;
+  while (p < buf.length) {
+    const b = buf[p++];
+    result |= (b & 0x7f) << shift;
+    if ((b & 0x80) === 0) break;
+    shift += 7;
+  }
+  return [result >>> 0, p];
+}
+
+// Minimal top-level parse of a HopMessage response — we only need the status
+// (field 5, varint) and whether a reservation (field 3) was returned.
+function parseHopResponse(buf: Uint8Array): { status?: number; hasReservation: boolean } {
+  let pos = 0;
+  let status: number | undefined;
+  let hasReservation = false;
+  while (pos < buf.length) {
+    const [tag, p1] = readVarint(buf, pos);
+    pos = p1;
+    const field = tag >>> 3;
+    const wire = tag & 0x7;
+    if (wire === 0) {
+      const [val, p2] = readVarint(buf, pos);
+      pos = p2;
+      if (field === 5) status = val;
+    } else if (wire === 2) {
+      const [len, p2] = readVarint(buf, pos);
+      pos = p2 + len;
+      if (field === 3) hasReservation = true;
+    } else if (wire === 1) {
+      pos += 8;
+    } else if (wire === 5) {
+      pos += 4;
+    } else {
+      break;
+    }
+  }
+  return { status, hasReservation };
+}
+
+/**
+ * Directly ask a relay for a reservation and log the exact status via our own
+ * logger. Replicates what circuitRelayTransport does internally, but surfaces
+ * the relay's answer (which libp2p otherwise only reports through debug logs)
+ * so we can tell a relay-side refusal from a client-side wiring problem.
+ */
+async function probeRelayReservation(node: any, relayPeerId: any): Promise<void> {
+  const relayIdShort = relayPeerId.toString().slice(0, 16);
+  try {
+    const stream = await node.dialProtocol(relayPeerId, RELAY_HOP_PROTOCOL, { signal: AbortSignal.timeout(10000) });
+    const lp = lpStream(stream);
+    // HopMessage { type: RESERVE } — field 1 (tag 0x08), enum RESERVE = 0.
+    await lp.write(Uint8Array.from([0x08, 0x00]));
+    const data = await lp.read({ signal: AbortSignal.timeout(10000) });
+    const { status, hasReservation } = parseHopResponse(data.subarray());
+    const name = status != null ? (HOP_STATUS_NAMES[status] ?? `code ${status}`) : 'unknown';
+    if (status === 100) {
+      logger.info(`🔬 Reservation probe to ${relayIdShort}... → ${name}${hasReservation ? ' (reservation granted)' : ' (OK but no reservation body)'} — relay accepts us; issue is client-side wiring`);
+    } else {
+      logger.warn(`🔬 Reservation probe to ${relayIdShort}... → ${name} — the relay refused the reservation`);
+    }
+    await lp.unwrap().close().catch(() => {});
+  } catch (err: any) {
+    logger.warn(`🔬 Reservation probe to ${relayIdShort}... failed before a status was returned: ${err?.message ?? err}`);
+  }
+}
 
 export const lookupBootstrapServers = async (): Promise<string[]> => {
   // No Bootstrap Servers Configured
@@ -46,6 +130,18 @@ export const lookupBootstrapServers = async (): Promise<string[]> => {
 };
 
 export const createLibp2pNode = async () => {
+  // Surface libp2p's own circuit-relay *errors* (only the :error namespaces, so
+  // no trace spam) via stderr. On a private node these show why a reservation
+  // failed; on the relay, `…:server:error` prints "failed to send confirmation
+  // response … - <err>" — the reason a RESERVE gets no reply. These bypass our
+  // logger, so check stderr (PM2 error log / `npm run node:logs`).
+  enableLibp2pLogs([
+    'libp2p:circuit-relay:transport:reservation-store:error',
+    'libp2p:circuit-relay:transport:listener:error',
+    'libp2p:circuit-relay:server:error',
+    'libp2p:circuit-relay:server:reservation-store:error',
+  ].join(','));
+
   // Load or Create a Peer ID
   const peer = await PeerIdManager.loadOrCreate('diiisco-peer-id.protobuf');
 
@@ -237,6 +333,11 @@ export const createLibp2pNode = async () => {
 
           if (hasHop) {
             logger.info(`🛰️  Relay ${relayId.slice(0, 16)}... advertises HOP [connected: ${connected}, reservation: ${reserved ? 'established' : 'pending'}]`);
+            // Reservation hasn't landed via the transport — ask the relay
+            // ourselves to capture the exact status.
+            if (!reserved && connected) {
+              await probeRelayReservation(node, peerIdObj);
+            }
           } else {
             logger.warn(`⚠️ Relay ${relayId.slice(0, 16)}... does NOT advertise circuit-relay HOP [connected: ${connected}] — it is not running as a relay server, so no reservation is possible`);
           }

--- a/src/messaging/directMessaging.ts
+++ b/src/messaging/directMessaging.ts
@@ -75,20 +75,15 @@ export class DirectMessagingHandler {
       knownAddrs = knownPeer.addresses.map((a: any) => a.multiaddr.toString());
     } catch { /* peer not yet in peerstore */ }
 
-    // If no addresses are known, query the DHT so relay circuit addrs can be discovered
-    // before we attempt to dial — otherwise dialProtocol times out doing the same thing.
-    if (knownAddrs.length === 0) {
-      try {
-        logger.info(`🔍 No addresses for ${peerId.slice(0, 16)}..., querying DHT...`);
-        const found = await this.node.peerRouting.findPeer(peerIdObj, { signal: AbortSignal.timeout(timeout) });
-        knownAddrs = found.multiaddrs.map((a: any) => a.toString());
-        logger.info(`🔍 DHT found ${knownAddrs.length} address(es) for ${peerId.slice(0, 16)}...: ${knownAddrs.join(', ')}`);
-        if (found.multiaddrs.length > 0) {
-          await this.node.peerStore.merge(peerIdObj, { multiaddrs: found.multiaddrs });
-        }
-      } catch (e: any) {
-        logger.info(`🔍 DHT lookup failed for ${peerId.slice(0, 16)}...: ${e.message}`);
-      }
+    // We deliberately do NOT query the DHT here. NATed peers are DHT clients and
+    // are unresolvable via findPeer, so the lookup only stalls for the timeout
+    // before failing. Instead we rely on addresses learned from the peer's
+    // signed messages (stamped multiaddrs). If we still have no way to reach the
+    // peer, bail out immediately and let the caller fall back to GossipSub.
+    const isConnected = this.node.getConnections(peerIdObj).length > 0;
+    if (knownAddrs.length === 0 && !isConnected) {
+      logger.debug(`🔀 No known addresses for ${peerId.slice(0, 16)}... — deferring to GossipSub`);
+      return false;
     }
 
     try {

--- a/src/messaging/directMessaging.ts
+++ b/src/messaging/directMessaging.ts
@@ -56,6 +56,10 @@ export class DirectMessagingHandler {
         logger.error(`❌ Error handling direct stream: ${err.message}`);
         stream.abort(err);
       });
+    }, {
+      // Relayed (circuit) connections are "limited" in libp2p v3 — custom
+      // protocols are refused on them unless we opt in here and on the dial.
+      runOnLimitedConnection: true,
     });
 
     logger.info(`✅ Direct messaging protocol registered: ${this.protocol}`);
@@ -93,7 +97,9 @@ export class DirectMessagingHandler {
       const stream = await this.node.dialProtocol(
         peerIdObj,
         this.protocol,
-        { signal: AbortSignal.timeout(timeout) }
+        // runOnLimitedConnection lets the stream open over a relay circuit
+        // (a limited connection); without it the dial is refused.
+        { signal: AbortSignal.timeout(timeout), runOnLimitedConnection: true }
       );
 
       // Encode message

--- a/src/messaging/messageProcessor.ts
+++ b/src/messaging/messageProcessor.ts
@@ -25,6 +25,8 @@ import { RawQuote } from "../types/quotes";
 import { Address } from "algosdk";
 import { MessageRouter } from './messageRouter';
 import { SpeculativeInferenceCache } from './speculativeInferenceCache';
+import { peerIdFromString } from '@libp2p/peer-id';
+import { multiaddr } from '@multiformats/multiaddr';
 
 export class MessageProcessor {
   private algo: algorand;
@@ -35,6 +37,7 @@ export class MessageProcessor {
   private messageRouter: MessageRouter;
   private env: Environment;
   private ownPeerId: string;
+  private node: any;
   private speculativeCache: SpeculativeInferenceCache;
 
   constructor(
@@ -44,7 +47,8 @@ export class MessageProcessor {
     availableModels: string[],
     nodeEvents: EventEmitter,
     messageRouter: MessageRouter,
-    ownPeerId: string
+    ownPeerId: string,
+    node: any
   ) {
     this.algo = algo;
     this.model = model;
@@ -54,6 +58,7 @@ export class MessageProcessor {
     this.messageRouter = messageRouter;
     this.env = environment;
     this.ownPeerId = ownPeerId;
+    this.node = node;
     this.speculativeCache = new SpeculativeInferenceCache(
       this.env.quoteEngine?.maxSpeculativeJobs ?? 2
     );
@@ -86,6 +91,11 @@ export class MessageProcessor {
       return false;
     }
     logger.info("🔐 Signature of incoming message has been successfully verified.");
+
+    // Learn how to reach the sender directly. The signed message carries the
+    // sender's current multiaddrs (incl. relay-circuit addresses), so we can
+    // populate the peerstore and later dial them without a DHT lookup.
+    await this.ingestSenderAddresses(msg, sourcePeerId);
 
     // Route to specific handler based on message role
     try {
@@ -128,6 +138,28 @@ export class MessageProcessor {
     } catch (err: any) {
       logger.error(`❌ Error processing ${msg.role} message: ${err.message}`);
       return false;
+    }
+  }
+
+  /**
+   * Merge the sender's advertised multiaddrs into the peerstore so that
+   * subsequent direct messages can dial them (over a relay circuit if needed)
+   * without relying on the DHT. Only called after the signature is verified, so
+   * the addresses are authenticated as belonging to the sending wallet.
+   */
+  private async ingestSenderAddresses(msg: PubSubMessage, sourcePeerId: string): Promise<void> {
+    const addrs = msg.multiaddrs;
+    if (!addrs || addrs.length === 0) return;
+    // GossipSub echoes our own messages back (emitSelf) — nothing to learn.
+    if (sourcePeerId === this.ownPeerId) return;
+
+    try {
+      const peerId = peerIdFromString(sourcePeerId);
+      const multiaddrs = addrs.map((a) => multiaddr(a));
+      await this.node.peerStore.merge(peerId, { multiaddrs });
+      logger.debug(`📍 Learned ${multiaddrs.length} address(es) for ${sourcePeerId.slice(0, 16)}... from ${msg.role}`);
+    } catch (err: any) {
+      logger.debug(`Could not ingest addresses from ${sourcePeerId.slice(0, 16)}...: ${err.message}`);
     }
   }
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -133,7 +133,26 @@ export interface ListNetworkResponse {
   signature?: string;
 }
 
-export type PubSubMessage = QuoteRequest | QuoteResponse | QuoteAccepted | ContractCreated | ContractSigned | InferenceResponse | ListModelsRequest | ListModelsResponse | ListNetworkRequest | ListNetworkResponse;
+export type PubSubMessage = (
+  | QuoteRequest
+  | QuoteResponse
+  | QuoteAccepted
+  | ContractCreated
+  | ContractSigned
+  | InferenceResponse
+  | ListModelsRequest
+  | ListModelsResponse
+  | ListNetworkRequest
+  | ListNetworkResponse
+) & {
+  /**
+   * Sender's current libp2p multiaddrs (including relay-circuit addresses),
+   * stamped onto every message at sign time. Lets peers dial the sender over a
+   * relay without a DHT lookup — NATed peers are DHT clients and so are not
+   * resolvable via findPeer. Part of the signed payload, so it is authenticated.
+   */
+  multiaddrs?: string[];
+};
 
 export interface QuoteEvent {
   msg: QuoteResponse;

--- a/src/utils/algorand.ts
+++ b/src/utils/algorand.ts
@@ -7,6 +7,7 @@ import { NfdClient } from '@txnlab/nfd-sdk';
 import { verify } from 'crypto';
 import { PubSubMessage } from '../types/messages';
 import { canonicalize } from 'json-canonicalize';
+import { getLocalMultiaddrs } from '../libp2p/localAddresses';
 import { diiiscoContract } from './contract';
 import { QuoteDetails, VerifyQuoteFundedResult } from '../types/algorand';
 import { ApplicationLocalState } from 'algosdk/client/algod';
@@ -155,6 +156,15 @@ export default class algorand {
   }
 
   async signObject(obj: any){
+    // Stamp our current multiaddrs (incl. relay-circuit addresses) onto the
+    // message so recipients can dial us over a relay without a DHT lookup. We
+    // mutate the caller's object in place so the transmitted message matches
+    // exactly what we sign here — otherwise verification would fail.
+    const addrs = getLocalMultiaddrs();
+    if (addrs.length > 0) {
+      obj.multiaddrs = addrs;
+    }
+
     // Remove signature field if it exists to avoid signing the signature itself
     if ('signature' in obj) {
       const { signature, ...objWithoutSignature } = obj;

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -1,18 +1,4 @@
-import type { RelayConfig, DirectMessagingConfig } from '../environment/environment.types';
-
-/**
- * Default relay configuration
- * Used when relay config is not specified in environment
- */
-export const DEFAULT_RELAY_CONFIG: RelayConfig = {
-  enableRelayServer: true,        // Auto-disabled by AutoNAT if behind NAT
-  autoEnableRelay: true,
-  maxRelayedConnections: 100,
-  enableRelayClient: true,
-  enableDCUtR: true,              // Upgrade relayed connections to direct when possible
-  maxDataPerConnection: 104857600,  // 100 MB
-  maxRelayDuration: 300000,       // 5 minutes
-};
+import type { DirectMessagingConfig } from '../environment/environment.types';
 
 /**
  * Default direct messaging configuration


### PR DESCRIPTION
Makes P2P direct messaging work when both nodes are behind NAT, by fully wiring up libp2p circuit-relay v2. Previously, messages between two NAT'd nodes had no dialable address and silently fell back to GossipSub; they now deliver directly over a relay circuit (with DCUtR upgrading to a direct connection where possible).