### PR TITLE
OpenAI Blank API Key

### DIFF
--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -17,7 +17,9 @@ export class OpenAIInferenceModel {
     this.env = environment;
     this.openai = new OpenAI({
       baseURL: baseURL,
-      apiKey: this.env.models.apiKey
+      // Local backends (Ollama, LM Studio) don't require a key, but the OpenAI
+      // SDK rejects a missing/empty one at construction time.
+      apiKey: this.env.models.apiKey || 'not-needed'
     });
     this.nodeEventEmitter = nodeEvents;
   }


### PR DESCRIPTION
Ensures blank API not sent to Ollama (ore any other provider) through OpenAI library.