### PR TITLE
Release 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diiisco-node",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Run a Diiisco Node in Node.JS!",
   "main": "dist/index.js",
   "type": "module",

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -17,7 +17,9 @@ export class OpenAIInferenceModel {
     this.env = environment;
     this.openai = new OpenAI({
       baseURL: baseURL,
-      apiKey: this.env.models.apiKey
+      // Local backends (Ollama, LM Studio) don't require a key, but the OpenAI
+      // SDK rejects a missing/empty one at construction time.
+      apiKey: this.env.models.apiKey || 'not-needed'
     });
     this.nodeEventEmitter = nodeEvents;
   }


### PR DESCRIPTION
🪲 Fixed a bug where a blank API string would get passed to the local model inference server. Recent versions of the OpenAI library do not allow this and flag an error.